### PR TITLE
Multiple 3D model paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ kicadStepUp-WB
 
 [![forthebadge made-with-python](http://ForTheBadge.com/images/badges/made-with-python.svg)](https://www.python.org/)
 
+This fork (from easyw/kicadStepUpMod) provides the following:
+- Imports the KiCAD preferences environment paths to better integrate 3D model paths with your KiCAD environment
+- Modifies the function of the 'main 3D folder' and 'secondary 3D folder' preferences to allow virtually unlimited number of paths specified in each field (currently only comma-separated lists).
+- - Currently multiple paths must be **manually entered** (each separated by comma) since the file select button allows only 1 selection.
+
 KiCad **StepUp tools** are a FreeCAD Macro and a FreeCAD WorkBench to help in **Mechanical Collaboration** between **KiCad EDA** and **FreeCAD** or a **Mechanical CAD**.
 
 **KiCad StepUp features:** 

--- a/Resources/ui/ksu_prefs.ui
+++ b/Resources/ui/ksu_prefs.ui
@@ -36,13 +36,67 @@
        <property name="title">
         <string>3D Prefix working folder</string>
        </property>
+       <widget class="QWidget" name="horizontalLayoutWidget_1">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>22</y>
+          <width>501</width>
+          <height>25</height>
+         </rect>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_1">
+         <item>
+          <widget class="QLabel" name="label_kicad_prefs">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Folder containing KiCAD prefs file (kicad_common)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>KiCAD prefs folder
+            </string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Gui::PrefFileChooser" name="kicad_prefs" native="true">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="baseSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Folder containing KiCAD prefs file (kicad_common)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="prefEntry" stdset="0">
+            <cstring>kicad_prefs</cstring>
+           </property>
+           <property name="prefPath" stdset="0">
+            <cstring>Mod/kicadStepUpGui</cstring>
+           </property>
+              <property name="mode">
+              <enum>Gui::FileChooser::Directory</enum>
+              </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
        <widget class="QWidget" name="horizontalLayoutWidget_2">
         <property name="geometry">
          <rect>
           <x>10</x>
-          <y>25</y>
+          <y>49</y>
           <width>501</width>
-          <height>34</height>
+          <height>25</height>
          </rect>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -94,9 +148,9 @@
         <property name="geometry">
          <rect>
           <x>10</x>
-          <y>65</y>
+          <y>76</y>
           <width>501</width>
-          <height>34</height>
+          <height>25</height>
          </rect>
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_3">

--- a/Resources/ui/ksu_prefs.ui
+++ b/Resources/ui/ksu_prefs.ui
@@ -103,7 +103,7 @@
          <item>
           <widget class="QLabel" name="label_prefix3d_2">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;ALIAS&lt;/span&gt; 3D&lt;/p&gt;&lt;p&gt;model prefix path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;ALIAS&lt;/span&gt; 3D&lt;/p&gt;&lt;p&gt;model prefix path&lt;/p&gt;&lt;p&gt;Can be a comma-separated list of paths to search.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
             <string>secondary 3D folder loc

--- a/kicadStepUptools.py
+++ b/kicadStepUptools.py
@@ -5022,6 +5022,220 @@ def check_wrl_transparency(step_module):
                 sayerr('wrz transparency NOT supported')
     return step_transparency
 ##
+
+def findModelPath(step_module, pathStr):     # Find module in all paths specified
+	module_path='not-found'
+	step_module=step_module.replace(u'"', u'')  # name with spaces
+	step_module2=step_module[:-4]+u'stp'
+	step_module3=step_module[:-4]+u'iges'
+	step_module4=step_module[:-4]+u'igs'
+	step_module5=step_module[:-4]+u'stpz'
+	# sayerr(step_module+' TEST')
+	#step_module=step_module.replace('"', '')  # name with spaces
+	#step_module=step_module.decode("utf-8").replace(u'"', u'')  # name with spaces
+	#step_module=step_module.encode("utf-8")
+	#sayw(models3D_prefix+step_module)
+	# removing 'backslash' for unicode_escape
+	## new utf-8 test
+	pathList=pathStr.split("\n")
+	if (len(pathList) == 1):
+		pathList=pathStr.split(',')
+	for _path in pathList:
+		models3D_prefix = re.sub("\\\\", "/", _path)
+		models3D_prefix_U = models3D_prefix
+		#if isinstance(models3D_prefix, str):
+		#    models3D_prefix_U = models3D_prefix.decode('unicode_escape')
+		#else:
+		#    models3D_prefix_U = models3D_prefix
+		step_module = re.sub("\\\\", "/", step_module)
+		#if isinstance(step_module, str):
+		#    step_module = step_module.decode('unicode_escape')
+		#else:
+		#    step_module = step_module.encode('utf-8')
+		#utf_path=os.path.join(models3D_prefix,step_module)
+		#print(type(step_module))  #maui test py3
+		utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module))
+		sayw(utf_path)
+		#utf_path=os.path.join(models3D_prefix,step_module)
+		##adding 2nd 3Dprefix support to step
+		#utf_path2=os.path.join(models3D_prefix2,step_module)
+		## new utf-8 test
+		sayw("Checking path: " + utf_path)
+		if os.path.exists(utf_path):
+			#module_path=models3D_prefix+step_module
+			module_path=utf_path
+			sayw("found! "+module_path)
+		else:
+			sayw("Checking path: " + step_module);
+			if os.path.exists(step_module): # absolute path
+				module_path=step_module
+				sayw("found! "+module_path)
+		#.STEP
+		if (module_path=='not-found'):
+			pos=utf_path.rfind('.')
+			rel_pos=len(utf_path)-pos
+			utf_path=utf_path[:-rel_pos+1]+u'STEP'
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+				#module_path=models3D_prefix+step_module
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				pos=step_module.rfind('.')
+				rel_pos=len(step_module)-pos
+				step_module_t=step_module[:-rel_pos+1]+u'STEP'
+				sayw("Checking path: " + step_module_t)
+				if os.path.exists(step_module_t): # absolute path
+					module_path=step_module_t
+					sayw("found! "+module_path)
+		#adding .stp support
+		#if isinstance(step_module2, str):
+		#    step_module = step_module2.decode('unicode_escape')
+		utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module2))
+		#sayerr(step_module2)
+		#sayerr(utf_path)
+		## new utf-8 test
+		if (module_path=='not-found'):
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+			#if os.path.exists(models3D_prefix+step_module2) and (module_path=='not-found'):
+				#module_path=models3D_prefix+step_module2
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				sayw("Checking path: " + step_module2)
+				if os.path.exists(step_module2): # absolute path
+					module_path=step_module2
+					sayw("found! "+module_path)
+		#sayerr(module_path)
+		#stop
+		#.STP
+		if (module_path=='not-found'):
+			pos=utf_path.rfind('.')
+			rel_pos=len(utf_path)-pos
+			utf_path=utf_path[:-rel_pos+1]+u'STP'
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+				#module_path=models3D_prefix+step_module
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				pos=step_module.rfind('.')
+				rel_pos=len(step_module2)-pos
+				step_module_t=step_module2[:-rel_pos+1]+u'STP'
+				sayw("Checking path: " + step_module_t)
+				if os.path.exists(step_module_t): # absolute path
+					module_path=step_module_t
+					sayw("found! "+module_path)
+		#adding .iges support
+		#if isinstance(step_module3, str):
+		#    step_module = step_module3.decode('unicode_escape')
+		utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module3))
+		## new utf-8 test
+		if (module_path=='not-found'):
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+			#if os.path.exists(models3D_prefix+step_module3) and (module_path=='not-found'):
+				#module_path=models3D_prefix_U+step_module3
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				sayw("Checking path: " + step_module3)
+				if os.path.exists(step_module3): # absolute path
+					module_path=step_module3
+					sayw("found3! "+module_path)
+		#.IGES
+		if (module_path=='not-found'):
+			pos=utf_path.rfind('.')
+			rel_pos=len(utf_path)-pos
+			utf_path=utf_path[:-rel_pos+1]+u'IGES'
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+				#module_path=models3D_prefix+step_module
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				pos=step_module.rfind('.')
+				rel_pos=len(step_module3)-pos
+				step_module_t=step_module3[:-rel_pos+1]+u'IGES'
+				sayw("Checking path: " + step_module_t)
+				if os.path.exists(step_module_t): # absolute path
+					module_path=step_module_t
+					sayw("found! "+module_path)
+		#if (module_path!='not-found'):
+		#    sayerr(module_path)
+		#    stop
+		#adding .igs support
+		utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module4))
+		## new utf-8 test
+		if (module_path=='not-found'):
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+			#if os.path.exists(models3D_prefix+step_module4) and (module_path=='not-found'):
+				#module_path=models3D_prefix_U+step_module4
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				sayw("Checking path: " + step_module5)
+				if os.path.exists(step_module5): # absolute path
+					module_path=step_module5
+					sayw("found! "+module_path)
+		#.IGS
+		if (module_path=='not-found'):
+			pos=utf_path.rfind('.')
+			rel_pos=len(utf_path)-pos
+			utf_path=utf_path[:-rel_pos+1]+u'IGS'
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+				#module_path=models3D_prefix+step_module
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				pos=step_module.rfind('.')
+				rel_pos=len(step_module4)-pos
+				step_module_t=step_module4[:-rel_pos+1]+u'IGS'
+				sayw("Checking path: " + step_module_t)
+				if os.path.exists(step_module_t): # absolute path
+					module_path=step_module_t
+					sayw("found! "+module_path)
+		#.stpZ
+		if (module_path=='not-found'):
+			pos=utf_path.rfind('.')
+			rel_pos=len(utf_path)-pos
+			utf_path=utf_path[:-rel_pos+1]+u'stpZ'
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+				#module_path=models3D_prefix+step_module
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				pos=step_module.rfind('.')
+				rel_pos=len(step_module5)-pos
+				step_module_t=step_module5[:-rel_pos+1]+u'stpZ'
+				sayw("Checking path: " + step_module_t)
+				if os.path.exists(step_module_t): # absolute path
+					module_path=step_module_t
+					sayw("found! "+module_path)
+		#.stpz
+		if (module_path=='not-found'):
+			pos=utf_path.rfind('.')
+			rel_pos=len(utf_path)-pos
+			utf_path=utf_path[:-rel_pos+1]+u'stpz'
+			sayw("Checking path: " + utf_path)
+			if os.path.exists(utf_path):
+				#module_path=models3D_prefix+step_module
+				module_path=utf_path
+				sayw("found! "+module_path)
+			else:
+				pos=step_module.rfind('.')
+				rel_pos=len(step_module5)-pos
+				step_module_t=step_module5[:-rel_pos+1]+u'stpz'
+				sayw("Checking path: " + step_module_t)
+				if os.path.exists(step_module_t): # absolute path
+					module_path=step_module_t
+					sayw("found! "+module_path)
+	return module_path
+###
 def Load_models(pcbThickness,modules):
     global off_x, off_y, volume_minimum, height_minimum, bbox_all, bbox_list
     global whitelisted_model_elements, models3D_prefix, models3D_prefix2, last_pcb_path, full_placement
@@ -5220,240 +5434,9 @@ def Load_models(pcbThickness,modules):
                 if model_name=="box_mcad" or model_name=="cylV_mcad" or model_name=="cylH_mcad":
                     createScaledObjs=True
                 if not createScaledObjs:
-                    module_path='not-found'
-                    step_module=step_module.replace(u'"', u'')  # name with spaces
-                    # sayerr(step_module+' TEST')
-                    #step_module=step_module.replace('"', '')  # name with spaces
-                    #step_module=step_module.decode("utf-8").replace(u'"', u'')  # name with spaces
-                    #step_module=step_module.encode("utf-8")
-                    #sayw(models3D_prefix+step_module)
-                    # removing 'backslash' for unicode_escape
-                    ## new utf-8 test
-                    models3D_prefix = re.sub("\\\\", "/", models3D_prefix)
-                    models3D_prefix_U = models3D_prefix
-                    #if isinstance(models3D_prefix, str):
-                    #    models3D_prefix_U = models3D_prefix.decode('unicode_escape')
-                    #else:
-                    #    models3D_prefix_U = models3D_prefix
-                    step_module = re.sub("\\\\", "/", step_module)
-                    #if isinstance(step_module, str):
-                    #    step_module = step_module.decode('unicode_escape')
-                    #else:
-                    #    step_module = step_module.encode('utf-8')
-                    #utf_path=os.path.join(models3D_prefix,step_module)
-                    #print(type(step_module))  #maui test py3
-                    utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module))
-                    #sayw(utf_path)
-                    #utf_path=os.path.join(models3D_prefix,step_module)
-                    ##adding 2nd 3Dprefix support to step
-                    #utf_path2=os.path.join(models3D_prefix2,step_module)
-                    ## new utf-8 test
-                    models3D_prefix2 = re.sub("\\\\", "/", models3D_prefix2)
-                    #if isinstance(models3D_prefix2, str):
-                    #    models3D_prefix2_U = models3D_prefix2.decode('unicode_escape')
-                    #else:
-                    #    models3D_prefix2_U = models3D_prefix2
-                    models3D_prefix2_U = models3D_prefix2
-                    utf_path2=os.path.join(make_unicode(models3D_prefix2_U),make_unicode(step_module)) # utf-8 chars
-                    #print(utf_path)
-                    #print(utf_path2)
-                    #print(step_module)
-                    #.step
-                    if os.path.exists(utf_path):
-                        #module_path=models3D_prefix+step_module
-                        module_path=utf_path
-                        #sayw("found! "+module_path)
-                    else:
-                        if os.path.exists(step_module): # absolute path
-                            module_path=step_module
-                        else:
-                            if os.path.exists(utf_path2):
-                                module_path=utf_path2
-                    #.STEP
+                    module_path=findModelPath(step_module, models3D_prefix)
                     if (module_path=='not-found'):
-                        pos=utf_path.rfind('.')
-                        rel_pos=len(utf_path)-pos
-                        utf_path=utf_path[:-rel_pos+1]+u'STEP'
-                        if os.path.exists(utf_path):
-                            #module_path=models3D_prefix+step_module
-                            module_path=utf_path
-                            #sayw("found! "+module_path)
-                        else:
-                            pos=step_module.rfind('.')
-                            rel_pos=len(step_module)-pos
-                            step_module_t=step_module[:-rel_pos+1]+u'STEP'
-                            if os.path.exists(step_module_t): # absolute path
-                                module_path=step_module_t
-                            else:
-                                pos=utf_path2.rfind('.')
-                                rel_pos=len(utf_path2)-pos
-                                utf_path2=utf_path2[:-rel_pos+1]+u'STEP'
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
-                    #adding .stp support
-                    #if isinstance(step_module2, str):
-                    #    step_module = step_module2.decode('unicode_escape')
-                    utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module2))
-                    utf_path2=os.path.join(make_unicode(models3D_prefix2_U),make_unicode(step_module2))
-                    #sayerr(step_module2)
-                    #sayerr(utf_path)
-                    #sayerr(utf_path2)
-                    ## new utf-8 test
-                    if (module_path=='not-found'):
-                        if os.path.exists(utf_path):
-                        #if os.path.exists(models3D_prefix+step_module2) and (module_path=='not-found'):
-                            #module_path=models3D_prefix+step_module2
-                            module_path=utf_path
-                            #sayw("found! "+module_path)
-                        else:
-                            if os.path.exists(step_module2): # absolute path
-                                module_path=step_module2
-                            else:
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
-                    #sayerr(module_path)
-                    #stop
-                    #.STP
-                    if (module_path=='not-found'):
-                        pos=utf_path.rfind('.')
-                        rel_pos=len(utf_path)-pos
-                        utf_path=utf_path[:-rel_pos+1]+u'STP'
-                        if os.path.exists(utf_path):
-                            #module_path=models3D_prefix+step_module
-                            module_path=utf_path
-                            #sayw("found! "+module_path)
-                        else:
-                            pos=step_module.rfind('.')
-                            rel_pos=len(step_module2)-pos
-                            step_module_t=step_module2[:-rel_pos+1]+u'STP'
-                            if os.path.exists(step_module_t): # absolute path
-                                module_path=step_module_t
-                            else:
-                                pos=utf_path2.rfind('.')
-                                rel_pos=len(utf_path2)-pos
-                                utf_path2=utf_path2[:-rel_pos+1]+u'STP'
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
-                    #adding .iges support
-                    #if isinstance(step_module3, str):
-                    #    step_module = step_module3.decode('unicode_escape')
-                    utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module3))
-                    utf_path2=os.path.join(make_unicode(models3D_prefix2_U),make_unicode(step_module3))
-                    ## new utf-8 test
-                    if (module_path=='not-found'):
-                        if os.path.exists(utf_path):
-                        #if os.path.exists(models3D_prefix+step_module3) and (module_path=='not-found'):
-                            #module_path=models3D_prefix_U+step_module3
-                            module_path=utf_path
-                        else:
-                            if os.path.exists(step_module3): # absolute path
-                                module_path=step_module3
-                                #sayw("found3! "+module_path)
-                            else:
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
-                    #.IGES
-                    if (module_path=='not-found'):
-                        pos=utf_path.rfind('.')
-                        rel_pos=len(utf_path)-pos
-                        utf_path=utf_path[:-rel_pos+1]+u'IGES'
-                        if os.path.exists(utf_path):
-                            #module_path=models3D_prefix+step_module
-                            module_path=utf_path
-                            #sayw("found! "+module_path)
-                        else:
-                            pos=step_module.rfind('.')
-                            rel_pos=len(step_module3)-pos
-                            step_module_t=step_module3[:-rel_pos+1]+u'IGES'
-                            if os.path.exists(step_module_t): # absolute path
-                                module_path=step_module_t
-                            else:
-                                pos=utf_path2.rfind('.')
-                                rel_pos=len(utf_path2)-pos
-                                utf_path2=utf_path2[:-rel_pos+1]+u'IGES'
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
-                    #if (module_path!='not-found'):
-                    #    sayerr(module_path)
-                    #    stop
-                    #adding .igs support
-                    utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module4))
-                    utf_path2=os.path.join(make_unicode(models3D_prefix2_U),make_unicode(step_module4))
-                    ## new utf-8 test
-                    if (module_path=='not-found'):
-                        if os.path.exists(utf_path):
-                        #if os.path.exists(models3D_prefix+step_module4) and (module_path=='not-found'):
-                            #module_path=models3D_prefix_U+step_module4
-                            module_path=utf_path
-                        else:
-                            if os.path.exists(step_module5): # absolute path
-                                module_path=step_module5
-                            else:
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
-                    #.IGS
-                    if (module_path=='not-found'):
-                        pos=utf_path.rfind('.')
-                        rel_pos=len(utf_path)-pos
-                        utf_path=utf_path[:-rel_pos+1]+u'IGS'
-                        if os.path.exists(utf_path):
-                            #module_path=models3D_prefix+step_module
-                            module_path=utf_path
-                            #sayw("found! "+module_path)
-                        else:
-                            pos=step_module.rfind('.')
-                            rel_pos=len(step_module4)-pos
-                            step_module_t=step_module4[:-rel_pos+1]+u'IGS'
-                            if os.path.exists(step_module_t): # absolute path
-                                module_path=step_module_t
-                            else:
-                                pos=utf_path2.rfind('.')
-                                rel_pos=len(utf_path2)-pos
-                                utf_path2=utf_path2[:-rel_pos+1]+u'IGS'
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
-                    #.stpZ
-                    if (module_path=='not-found'):
-                        pos=utf_path.rfind('.')
-                        rel_pos=len(utf_path)-pos
-                        utf_path=utf_path[:-rel_pos+1]+u'stpZ'
-                        if os.path.exists(utf_path):
-                            #module_path=models3D_prefix+step_module
-                            module_path=utf_path
-                            #sayw("found! "+module_path)
-                        else:
-                            pos=step_module.rfind('.')
-                            rel_pos=len(step_module5)-pos
-                            step_module_t=step_module5[:-rel_pos+1]+u'stpZ'
-                            if os.path.exists(step_module_t): # absolute path
-                                module_path=step_module_t
-                            else:
-                                pos=utf_path2.rfind('.')
-                                rel_pos=len(utf_path2)-pos
-                                utf_path2=utf_path2[:-rel_pos+1]+u'stpZ'
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
-                    #.stpz
-                    if (module_path=='not-found'):
-                        pos=utf_path.rfind('.')
-                        rel_pos=len(utf_path)-pos
-                        utf_path=utf_path[:-rel_pos+1]+u'stpz'
-                        if os.path.exists(utf_path):
-                            #module_path=models3D_prefix+step_module
-                            module_path=utf_path
-                            #sayw("found! "+module_path)
-                        else:
-                            pos=step_module.rfind('.')
-                            rel_pos=len(step_module5)-pos
-                            step_module_t=step_module5[:-rel_pos+1]+u'stpz'
-                            if os.path.exists(step_module_t): # absolute path
-                                module_path=step_module_t
-                            else:
-                                pos=utf_path2.rfind('.')
-                                rel_pos=len(utf_path2)-pos
-                                utf_path2=utf_path2[:-rel_pos+1]+u'stpz'
-                                if os.path.exists(utf_path2):
-                                    module_path=utf_path2
+                    	module_path=findModelPath(step_module, models3D_prefix2)
                 else:
                     scale_vrml=modules[i][8]
                     #sayw(scale_vrml)

--- a/kicadStepUptools.py
+++ b/kicadStepUptools.py
@@ -6061,7 +6061,8 @@ def Load_models(pcbThickness,modules):
         last_pcb_path_local = re.sub("\\\\", "/", last_pcb_path)
         last_pcb_path_local_U = make_unicode(last_pcb_path_local)
         say("missing models");say (missing_models)
-        say("searching path");say(models3D_prefix_U);say (models3D_prefix2_U)
+        #say("searching path");say(models3D_prefix_U);say (models3D_prefix2_U)
+        say("searching path");say(models3D_prefix);say (models3D_prefix2)
         say(last_pcb_path_local_U)
         missings=[]
         missings=missing_models.split('\r\n')
@@ -6069,8 +6070,10 @@ def Load_models(pcbThickness,modules):
         #if len (missings) > n_rpt_max: #warning_nbr =-1 for skipping the test
         wmsg="""... missing module(s)<br>"""
         wmsg+="""... searching path:<br>"""
-        wmsg+=models3D_prefix_U+"""<br>"""
-        wmsg+=models3D_prefix2_U+"""<br>"""
+        #wmsg+=models3D_prefix_U+"""<br>"""
+        #wmsg+=models3D_prefix2_U+"""<br>"""
+        wmsg+=models3D_prefix+"""<br>"""
+        wmsg+=models3D_prefix2+"""<br>"""
         wmsg+=last_pcb_path_local_U+"""<br>"""
         wmsg+="""... missing module(s) '.step' or '.stp' or .iges' or '.igs'<br>"""
         for i in range(min(len (missings),n_rpt_max)):

--- a/kicadStepUptools.py
+++ b/kicadStepUptools.py
@@ -5055,39 +5055,39 @@ def findModelPath(step_module, pathStr):     # Find module in all paths specifie
 		#utf_path=os.path.join(models3D_prefix,step_module)
 		#print(type(step_module))  #maui test py3
 		utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module))
-		sayw(utf_path)
+		#sayw(utf_path)
 		#utf_path=os.path.join(models3D_prefix,step_module)
 		##adding 2nd 3Dprefix support to step
 		#utf_path2=os.path.join(models3D_prefix2,step_module)
 		## new utf-8 test
-		sayw("Checking path: " + utf_path)
+		#sayw("Checking path: " + utf_path)
 		if os.path.exists(utf_path):
 			#module_path=models3D_prefix+step_module
 			module_path=utf_path
-			sayw("found! "+module_path)
+			#sayw("found! "+module_path)
 		else:
-			sayw("Checking path: " + step_module);
+			#sayw("Checking path: " + step_module);
 			if os.path.exists(step_module): # absolute path
 				module_path=step_module
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 		#.STEP
 		if (module_path=='not-found'):
 			pos=utf_path.rfind('.')
 			rel_pos=len(utf_path)-pos
 			utf_path=utf_path[:-rel_pos+1]+u'STEP'
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 				#module_path=models3D_prefix+step_module
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
 				pos=step_module.rfind('.')
 				rel_pos=len(step_module)-pos
 				step_module_t=step_module[:-rel_pos+1]+u'STEP'
-				sayw("Checking path: " + step_module_t)
+				#sayw("Checking path: " + step_module_t)
 				if os.path.exists(step_module_t): # absolute path
 					module_path=step_module_t
-					sayw("found! "+module_path)
+					#sayw("found! "+module_path)
 		#adding .stp support
 		#if isinstance(step_module2, str):
 		#    step_module = step_module2.decode('unicode_escape')
@@ -5096,17 +5096,17 @@ def findModelPath(step_module, pathStr):     # Find module in all paths specifie
 		#sayerr(utf_path)
 		## new utf-8 test
 		if (module_path=='not-found'):
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 			#if os.path.exists(models3D_prefix+step_module2) and (module_path=='not-found'):
 				#module_path=models3D_prefix+step_module2
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
-				sayw("Checking path: " + step_module2)
+				#sayw("Checking path: " + step_module2)
 				if os.path.exists(step_module2): # absolute path
 					module_path=step_module2
-					sayw("found! "+module_path)
+					#sayw("found! "+module_path)
 		#sayerr(module_path)
 		#stop
 		#.STP
@@ -5114,54 +5114,54 @@ def findModelPath(step_module, pathStr):     # Find module in all paths specifie
 			pos=utf_path.rfind('.')
 			rel_pos=len(utf_path)-pos
 			utf_path=utf_path[:-rel_pos+1]+u'STP'
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 				#module_path=models3D_prefix+step_module
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
 				pos=step_module.rfind('.')
 				rel_pos=len(step_module2)-pos
 				step_module_t=step_module2[:-rel_pos+1]+u'STP'
-				sayw("Checking path: " + step_module_t)
+				#sayw("Checking path: " + step_module_t)
 				if os.path.exists(step_module_t): # absolute path
 					module_path=step_module_t
-					sayw("found! "+module_path)
+					#sayw("found! "+module_path)
 		#adding .iges support
 		#if isinstance(step_module3, str):
 		#    step_module = step_module3.decode('unicode_escape')
 		utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module3))
 		## new utf-8 test
 		if (module_path=='not-found'):
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 			#if os.path.exists(models3D_prefix+step_module3) and (module_path=='not-found'):
 				#module_path=models3D_prefix_U+step_module3
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
-				sayw("Checking path: " + step_module3)
+				#sayw("Checking path: " + step_module3)
 				if os.path.exists(step_module3): # absolute path
 					module_path=step_module3
-					sayw("found3! "+module_path)
+					#sayw("found3! "+module_path)
 		#.IGES
 		if (module_path=='not-found'):
 			pos=utf_path.rfind('.')
 			rel_pos=len(utf_path)-pos
 			utf_path=utf_path[:-rel_pos+1]+u'IGES'
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 				#module_path=models3D_prefix+step_module
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
 				pos=step_module.rfind('.')
 				rel_pos=len(step_module3)-pos
 				step_module_t=step_module3[:-rel_pos+1]+u'IGES'
-				sayw("Checking path: " + step_module_t)
+				#sayw("Checking path: " + step_module_t)
 				if os.path.exists(step_module_t): # absolute path
 					module_path=step_module_t
-					sayw("found! "+module_path)
+					#sayw("found! "+module_path)
 		#if (module_path!='not-found'):
 		#    sayerr(module_path)
 		#    stop
@@ -5169,72 +5169,114 @@ def findModelPath(step_module, pathStr):     # Find module in all paths specifie
 		utf_path=os.path.join(make_unicode(models3D_prefix_U),make_unicode(step_module4))
 		## new utf-8 test
 		if (module_path=='not-found'):
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 			#if os.path.exists(models3D_prefix+step_module4) and (module_path=='not-found'):
 				#module_path=models3D_prefix_U+step_module4
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
-				sayw("Checking path: " + step_module5)
+				#sayw("Checking path: " + step_module5)
 				if os.path.exists(step_module5): # absolute path
 					module_path=step_module5
-					sayw("found! "+module_path)
+					#sayw("found! "+module_path)
 		#.IGS
 		if (module_path=='not-found'):
 			pos=utf_path.rfind('.')
 			rel_pos=len(utf_path)-pos
 			utf_path=utf_path[:-rel_pos+1]+u'IGS'
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 				#module_path=models3D_prefix+step_module
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
 				pos=step_module.rfind('.')
 				rel_pos=len(step_module4)-pos
 				step_module_t=step_module4[:-rel_pos+1]+u'IGS'
-				sayw("Checking path: " + step_module_t)
+				#sayw("Checking path: " + step_module_t)
 				if os.path.exists(step_module_t): # absolute path
 					module_path=step_module_t
-					sayw("found! "+module_path)
+					#sayw("found! "+module_path)
 		#.stpZ
 		if (module_path=='not-found'):
 			pos=utf_path.rfind('.')
 			rel_pos=len(utf_path)-pos
 			utf_path=utf_path[:-rel_pos+1]+u'stpZ'
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 				#module_path=models3D_prefix+step_module
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
 				pos=step_module.rfind('.')
 				rel_pos=len(step_module5)-pos
 				step_module_t=step_module5[:-rel_pos+1]+u'stpZ'
-				sayw("Checking path: " + step_module_t)
+				#sayw("Checking path: " + step_module_t)
 				if os.path.exists(step_module_t): # absolute path
 					module_path=step_module_t
-					sayw("found! "+module_path)
+					#sayw("found! "+module_path)
 		#.stpz
 		if (module_path=='not-found'):
 			pos=utf_path.rfind('.')
 			rel_pos=len(utf_path)-pos
 			utf_path=utf_path[:-rel_pos+1]+u'stpz'
-			sayw("Checking path: " + utf_path)
+			#sayw("Checking path: " + utf_path)
 			if os.path.exists(utf_path):
 				#module_path=models3D_prefix+step_module
 				module_path=utf_path
-				sayw("found! "+module_path)
+				#sayw("found! "+module_path)
 			else:
 				pos=step_module.rfind('.')
 				rel_pos=len(step_module5)-pos
 				step_module_t=step_module5[:-rel_pos+1]+u'stpz'
-				sayw("Checking path: " + step_module_t)
+				#sayw("Checking path: " + step_module_t)
 				if os.path.exists(step_module_t): # absolute path
 					module_path=step_module_t
-					sayw("found! "+module_path)
+					#sayw("found! "+module_path)
 	return module_path
+###
+def loadKiCadPrefsPaths():
+	paths = {}
+	prefPath = prefs.GetString('kicad_prefs')
+	if len(prefPath) > 0:
+		prefPath += '/kicad_common'
+		if os.path.exists(prefPath):
+			say('Opening KiCAD prefs path: ' + prefPath)
+			f = builtin.open(prefPath)
+			if f:
+				inEnv = False
+				for l in f:
+					l = l.strip()
+					if l == '[EnvironmentVariables]':
+						inEnv = True
+					elif inEnv:
+						l = l.split('=')
+						if len(l) == 2:
+							k = l[0].strip()
+							v = l[1].strip()
+							if v[0] == '/':		# Collect the path only if it is an absolute path on the local system
+								paths[k] = v
+				f.close()
+			else:
+				say('Failed!')
+	#say('Num of paths: ' + str(len(paths)))
+	#for f in paths:
+	#	say('path: ' + f + '=' + paths[f])
+	return paths
+###
+def makeKiCadPath(modelPath, kicadPaths, varC = '{}'):
+	pathMacros = re.findall('\$'+varC[0]+'.*?'+varC[1]+'/', modelPath)
+	for p1 in pathMacros:
+		p2 = re.sub('\$'+varC[0], '', p1)
+		p2 = re.sub(varC[1]+'/', '', p2)
+		#say('pathMacro: ' + p2)
+		if p2 in kicadPaths and len(kicadPaths[p2]):
+			p = modelPath.replace(p1, kicadPaths[p2] + '/')
+			if os.path.exists(p):				# Replace the path only if the file exists so that if not exists other steps might be able to adjust the path if possible
+				modelPath = p
+				#say('Model path: ' + modelPath)
+	return modelPath
 ###
 def Load_models(pcbThickness,modules):
     global off_x, off_y, volume_minimum, height_minimum, bbox_all, bbox_list
@@ -5261,6 +5303,7 @@ def Load_models(pcbThickness,modules):
     botV_name='BotV'+fname_sfx
     stepM_name='Step_Models'+fname_sfx
     stepV_name='Step_Virtual_Models'+fname_sfx
+    kicad_paths = loadKiCadPrefsPaths()            # Load KiCAD prefs environment paths
                             
     for i in range(len(modules)):
         step_module=modules[i][0]
@@ -5327,6 +5370,7 @@ def Load_models(pcbThickness,modules):
             say('adjusting Local Path')
             say('step-module-replaced '+step_module)
         if (step_module.find('${')!=-1) and encoded==0:  #extra local ${ENV} 3D path
+            step_module = makeKiCadPath(step_module, kicad_paths, '{}')
             step_module= re.sub('\${.*?}/', '', step_module)
             #step_module=step_module.decode("utf-8").replace(u'${}/', u'')
             step_module=step_module.replace(u'${}/', u'')
@@ -5335,6 +5379,7 @@ def Load_models(pcbThickness,modules):
             say('adjusting 2nd Local Path')
             say('step-module-replaced '+step_module)      
         elif (step_module.find('$(')!=-1) and encoded==0:  #extra local $(ENV) 3D path
+            step_module = makeKiCadPath(step_module, kicad_paths, '()')
             step_module= re.sub('\$(.*?)/', '', step_module)
             #step_module=step_module.decode("utf-8").replace(u'${}/', u'')
             step_module=step_module.replace(u'$()/', u'')


### PR DESCRIPTION
Add ability to search multiple paths for 3D models.
Multiple paths can be configured in 'main 3D folder location' and 'secondary 3D folder loc' fields.
These 2 fields can be comma or carriage return separated lists of paths.
Currently multiple paths in these fields must be manually entered and not by using the '...' button.