### PR TITLE
Ignore errors when loading primitives

### DIFF
--- a/kicad_parser.py
+++ b/kicad_parser.py
@@ -325,7 +325,7 @@ def makePrimitve(key, params):
         else:
             make_shape = globals()['make_{}'.format(key)]
             return make_shape(params), width
-    except KeyError:
+    except (KeyError, TypeError):
         logger.warning('Unknown primitive {} in custom pad'.format(key))
         return None, None
 


### PR DESCRIPTION
Loading tracks for my PCB design leads to:

```
17:23:32  Running the Python command 'ksuToolsAddTracks' failed:
Traceback (most recent call last):
  File "/home/user/.FreeCAD/Mod/kicadStepUpMod/kicadStepUpCMD.py", line 3415, in Activated
    tracks.addtracks()
  File "/home/user/.FreeCAD/Mod/kicadStepUpMod/tracks.py", line 346, in addtracks
    pcb.makePads(shape_type='face',thickness=0.05,holes=True,fit_arcs=True) #,prefix='')
  File "/home/user/.FreeCAD/Mod/kicadStepUpMod/kicad_parser.py", line 1617, in makePads
    w = self._makeCustomPad(p)
  File "/home/user/.FreeCAD/Mod/kicadStepUpMod/kicad_parser.py", line 1538, in _makeCustomPad
    wire,width = makePrimitve(key, getattr(params.primitives, key))
  File "/home/user/.FreeCAD/Mod/kicadStepUpMod/kicad_parser.py", line 322, in makePrimitve
    width = getattr(params,'width',0)
  File "/home/user/.FreeCAD/Mod/kicadStepUpMod/fcad_parser/sexp_parser/sexp_parser.py", line 177, in __getattr__
    return self.__getitem__(name)
  File "/home/user/.FreeCAD/Mod/kicadStepUpMod/fcad_parser/sexp_parser/sexp_parser.py", line 147, in __getitem__
    v = self._value[key]
```

list indices must be integers or slices, not str

Note: This probably is not the right fix, but I am not sure how to fix the problem properly.