### PR TITLE
Correct classname in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
 
   <content>
     <workbench>
-      <classname>KicadStepUp Workbench</classname>
+      <classname>KiCadStepUpWB</classname>
       <subdirectory>./</subdirectory>
       <freecadmin>0.17.0</freecadmin>
       <tag>kicad</tag>


### PR DESCRIPTION
The name of the entry class in InitGui.py is `KiCadStepUpWB`.