### PR TITLE
Fix tracks import for custom pad with multiple primitives of the same type

### DIFF
--- a/kicad_parser.py
+++ b/kicad_parser.py
@@ -1624,15 +1624,21 @@ class KicadFcad:
 
     def _makeCustomPad(self, params):
         wires = []
-        for key in params.primitives:
-            wire,width = makePrimitve(key, getattr(params.primitives, key))
-            if not width:
-                if isinstance(wire, Part.Edge):
-                    wire = Part.Wire(wire)
-                wires.append(wire)
-            else:
-                wire = self._makeWires(wire, name=None, offset=width*0.5)
-                wires += wire.Wires
+        primitive_types = params.primitives
+        for key in primitive_types:
+            # If there are multiple primitives of the same type (e.g. gr_arc), the node is parsed
+            # to a SexpList, otherwise for a single primitive it's a SexpValueDict. Wrap in a
+            # SexpList if necessary so we can handle both cases the same way.
+            primitives = SexpList(getattr(primitive_types, key))
+            for primitive in primitives:
+                wire,width = makePrimitve(key, primitive)
+                if not width:
+                    if isinstance(wire, Part.Edge):
+                        wire = Part.Wire(wire)
+                    wires.append(wire)
+                else:
+                    wire = self._makeWires(wire, name=None, offset=width*0.5)
+                    wires += wire.Wires
         if not wires:
             return
         if len(wires) == 1:


### PR DESCRIPTION
Track import would fail with a `list indices must be integers or slices, not str` error if a custom pad used multiple instances of the same primitive type (e.g. multiple gr_arcs), but worked if each type of primitive appears at most once.

The SexpParser is a little weird in that the type of items changes if there's just 1 item vs 2 with the same key, but this seems like a pattern used elsewhere in `kicad_parser.py` to handle both cases.

Fixes #106 and is probably a preferable fix compared to #111

Video demonstrating the error and the fix on FreeCAD nightly 0.21 with a demo KiCad 6 PCB:
https://user-images.githubusercontent.com/414890/211234684-f1acaf39-aa9e-4185-bbba-4d987c22c0a6.mp4

Demo PCB is using the `Infineon_PG-HSOF-8-1_ThermalVias` footprint identified as an issue in https://github.com/easyw/kicadStepUpMod/issues/106#issuecomment-1310326746

Demo PCB: 
[kicadstepup_custom_pad_demo.zip](https://github.com/easyw/kicadStepUpMod/files/10370125/kicadstepup_custom_pad_demo.zip)

