### PR TITLE
Name KiCad zones after selected sketch 

### DIFF
--- a/kicadStepUpCMD.py
+++ b/kicadStepUpCMD.py
@@ -1460,7 +1460,8 @@ class ksuToolsPushPCB:
                 ## sk = Draft.make_sketch(s.Edges, autoconstraints=True)
                 kicadStepUptools.sanitizeSketch(sketch.Name)
                 FreeCAD.ActiveDocument.recompute()
-                sk = Draft.make_sketch(sketch, autoconstraints=True)
+                # match the labels, append a suffix to avoid duplicates in the tree and remove later
+                sk = Draft.make_sketch(sketch, autoconstraints=True, name=f'{sketch.Label}_{kicadStepUptools.__name__}')
                 sk_obj = FreeCAD.ActiveDocument.ActiveObject
                 FreeCAD.ActiveDocument.recompute()
                 FreeCADGui.Selection.clearSelection()

--- a/kicadStepUptools.py
+++ b/kicadStepUptools.py
@@ -21185,8 +21185,10 @@ def pushFillZone(skn, ofs, keepout=None):
     segments_nbr=len(edges)
     if segments_nbr<3:
         stop
+    skn = skn or ""
+    if skn.endswith(f'_{__name__}'): skn = skn[:-len(f'_{__name__}')]
     if 'Fill' in keepout:
-        fillzone = """  (zone (net 0) (net_name "") (layer """+keepout[:1]+""".Cu) (tstamp 0) (hatch edge 0.508)"""+os.linesep
+        fillzone = """  (zone (net 0) (net_name "") (layer """+keepout[:1]+""".Cu) (tstamp 0) (name \""""+skn+"""\") (hatch edge 0.508)"""+os.linesep
         fillzone+="""    (connect_pads (clearance 0.508))"""+os.linesep
         fillzone+="""    (min_thickness 0.254)"""+os.linesep
         fillzone+="""    (fill yes (arc_segments 32) (thermal_gap 0.508) (thermal_bridge_width 0.508))"""+os.linesep
@@ -21194,7 +21196,7 @@ def pushFillZone(skn, ofs, keepout=None):
     elif 'Mask' in keepout:
         fillzone = """  (gr_poly"""+os.linesep
     elif 'KeepOut' in keepout: #keepout zone
-        fillzone = """  (zone (net 0) (net_name "") (layers """+keepout[:1]+""".Cu) (tstamp 0) (hatch edge 0.508)"""+os.linesep
+        fillzone = """  (zone (net 0) (net_name "") (layers """+keepout[:1]+""".Cu) (tstamp 0) (name \""""+skn+"""\") (hatch edge 0.508)"""+os.linesep
         fillzone+="""    (connect_pads (clearance 0.508))"""+os.linesep
         fillzone+="""    (min_thickness 0.254)"""+os.linesep
         fillzone+="""    (keepout (tracks not_allowed) (vias not_allowed) (copperpour not_allowed))"""+os.linesep


### PR DESCRIPTION
Adds a minor feature that when Fills and KeepOuts are exported from FreeCad they are named after the selected sketch when using KiCadStepUp WB -> Push Sketch to PCB.

It's written using python that I believe would be compatible back to 3.6, if python >3.9 is enforced removing the prefix would be a simpler `skn.removeprefix()` call. 

| FreeCad 0.20.2 | KiCad 8.0.3-rc3 |
| --- | --- | 
| ![freecad setup](https://github.com/easyw/kicadStepUpMod/assets/4967528/96723da1-a5a7-4857-8143-cd465b0c6566) | ![named zone in kicad](https://github.com/easyw/kicadStepUpMod/assets/4967528/f60ee4ff-00c6-4196-949d-d3adb2d4347f)
