### PR TITLE
Directly open KiCadStepUp preferences page when running `ksuToolsEditPrefs`

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -86,62 +86,55 @@ class kSU_MainPrefPage:
                 importlib.reload(lib)
             else:
                 reload (lib)
-        
+
         print ("Created kSU Auxiliary Pref page")
-        
+
         # https://stackoverflow.com/questions/71852282/qt-designer-not-playing-nicely-with-windows-display-scaling
         # https://stackoverflow.com/questions/20464814/changing-dpi-scaling-size-of-display-make-qt-applications-font-size-get-rendere
-        
+
         #help_t = hlp.help_txt
         #reload_lib(hlp)
         header_txt="""<font color=GoldenRod><b>kicad StepUp version """+verKSU+"""</font></b><br>"""
         help_t = header_txt+hlp.help_txt
         self.form = QtGui.QWidget()
         #self.form.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
-        
+
         # mw1 = FreeCADGui.getMainWindow()
         # print ('physical DPI',mw1.screen().physicalDotsPerInch())
         # print ('logical  DPI',mw1.screen().logicalDotsPerInch())
-            
+
         print ('physical aux page',self.form.physicalDpiX())
         print ('logical  aux page',self.form.logicalDpiX())
         scaling = self.form.logicalDpiX() / self.form.physicalDpiX() # /96.0  # self is of QWidget
         print ('scaling aux page',scaling)
         # print(self.form.screen.devicePixelRatio())
-        self.form.setWindowTitle("kSU \'Help Tips\'")
-        self.form.verticalLayoutWidget = QtGui.QWidget(self.form)
-        # w = 560*scaling; h = 630*scaling
-        # self.form.verticalLayoutWidget.setGeometry(QtCore.QRect(0, 0, w, h)) #top corner, width, height
-        self.form.verticalLayoutWidget.setGeometry(QtCore.QRect(0, 0, 560, 630)) #top corner, width, height
-        self.form.verticalLayoutWidget.setObjectName("verticalLayoutWidget")
-        self.form.verticalLayout = QtGui.QVBoxLayout(self.form.verticalLayoutWidget)
-        self.form.verticalLayout.setContentsMargins(0, 0, 0, 0)
-        self.form.verticalLayout.setObjectName("verticalLayout")
-        #self.form.label = QtGui.QLabel(self.form.verticalLayoutWidget)
-        #self.form.label.setObjectName("label")
-        #self.form.label.setText("Hello world!")
-        #self.form.verticalLayout.addWidget(self.form.label)
-        self.form.textEdit = QtGui.QTextBrowser(self.form.verticalLayoutWidget)
-        # self.form.textEdit.setGeometry(QtCore.QRect(00, 10, w-20, h-20)) #top corner, width, height
-        self.form.textEdit.setGeometry(QtCore.QRect(00, 10, 540, 610)) #top corner, width, height
+        self.form.setWindowTitle("kSU 'Help Tips'")
+        self.form.mainLayout = QtGui.QGridLayout(self.form)
+        self.form.mainLayout.setObjectName("mainLayout")
+        self.form.groupBox = QtGui.QGroupBox("KSU Help Tips", self.form)
+        self.form.groupBoxLayout = QtGui.QVBoxLayout(self.form.groupBox)
+        self.form.groupBoxLayout.setObjectName("groupBoxLayout")
+        self.form.textEdit = QtGui.QTextBrowser(self.form.groupBox)
         self.form.textEdit.setOpenExternalLinks(True)
         self.form.textEdit.setObjectName("textEdit")
-        self.form.textEdit.setText(help_t)        
-# Button UI
+        self.form.textEdit.setText(help_t)
+        self.form.groupBoxLayout.addWidget(self.form.textEdit)
+        self.form.mainLayout.addWidget(self.form.groupBox, 0, 0, 1, 1)
+        # Button UI
         add_button=False
         if add_button:
             self.form.btn = QtGui.QPushButton('Create Folder', self.form.verticalLayoutWidget)
             self.form.btn.setToolTip('This creates the folders.')
             self.form.btn.resize(self.form.btn.sizeHint())
-            self.form.btn.move(5, 60)       
-            self.form.btn.clicked.connect(self.selectDirectory)   
-            self.form.verticalLayout.addWidget(self.form.btn)        
-        
+            self.form.btn.move(5, 60)
+            self.form.btn.clicked.connect(self.selectDirectory)
+            self.form.verticalLayout.addWidget(self.form.btn)
+
     def saveSettings(self):
         print ("saveSettings Helper")
         import SaveSettings
         SaveSettings.update_ksuGui()
-        
+
     def loadSettings(self):
         print ("loadSettings Helper")
         prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/kicadStepUpGui").GetString('prefix3d_1')+'/'
@@ -151,7 +144,7 @@ class kSU_MainPrefPage:
         #    for p in prefs.GetContents():
         #        print (p)
         print(FreeCAD.getUserAppDataDir())
-##
+
 class KiCadStepUpWB ( Workbench ):
     from TranslateUtils import translate
     global main_ksu_Icon, ksu_wb_version, myurlKWB, mycommitsKWB, verKSU

--- a/InitGui.py
+++ b/InitGui.py
@@ -404,7 +404,7 @@ class KiCadStepUpWB ( Workbench ):
             """
             QtGui.QApplication.restoreOverrideCursor()
             reply = QtGui.QMessageBox.information(None,"Warning", msg)
-            # FreeCADGui.runCommand("Std_DlgPreferences") it cannot launched here until InitGui has run!!!
+            # FreeCADGui.showPreferences("kicadStepUpGui") it cannot launched here until InitGui has run!!!
         ##
         time_interval = pg.GetInt("updateDaysInterval")
         if time_interval <= 0:

--- a/Resources/ui/ksu_prefs.ui
+++ b/Resources/ui/ksu_prefs.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>558</width>
-    <height>904</height>
+    <width>639</width>
+    <height>1040</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>General</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout1" rowstretch="0" rowminimumheight="0">
+  <layout class="QGridLayout" name="gridLayout1" rowstretch="0,0,0,0,0,0">
    <property name="leftMargin">
     <number>10</number>
    </property>
@@ -29,1399 +29,1247 @@
    <property name="spacing">
     <number>6</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="imp_exp_setting">
+     <property name="title">
+      <string>Import/Export settings</string>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>600</height>
-      </size>
-     </property>
-     <property name="verticalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOn</enum>
-     </property>
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>522</width>
-        <height>900</height>
-       </rect>
-      </property>
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>900</height>
-       </size>
-      </property>
-      <widget class="QGroupBox" name="prefix_3d_group">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>538</width>
-         <height>901</height>
-        </rect>
-       </property>
-       <property name="title">
-        <string>3D Prefix working folder</string>
-       </property>
-       <widget class="QWidget" name="horizontalLayoutWidget_2">
-        <property name="geometry">
-         <rect>
-          <x>10</x>
-          <y>25</y>
-          <width>501</width>
-          <height>39</height>
-         </rect>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_make_union">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable/Disable &lt;span style=&quot; font-weight:600;&quot;&gt;fusion (union)&lt;/span&gt; of all 3D models.&lt;/p&gt;&lt;p&gt;Be careful ... fusion can be heavy or generate FC crash with a lot of objects.&lt;/p&gt;&lt;p&gt;Please consider to use bbox or blacklist small objects&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <item>
-          <widget class="QLabel" name="label_prefix3d_1">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;KISYS3DMOD&lt;/span&gt; path&lt;/p&gt;&lt;p&gt;or 3D model &lt;span style=&quot; font-weight:600;&quot;&gt;main prefix path&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
+        <property name="text">
+         <string>Make a Union of 3D models</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>make_union</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/kicadStepUpGui</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_exp_step">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Directly &lt;span style=&quot; font-weight:600;&quot;&gt;Export STEP&lt;/span&gt; after Loading&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Directly Export STEP after Loading</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>exp_step</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/kicadStepUpGui</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_11">
+        <item>
+         <widget class="QLabel" name="label_19">
+          <property name="toolTip">
+           <string>STEP export mode.</string>
+          </property>
+          <property name="text">
+           <string>STEP export mode</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_4">
+          <property name="toolTip">
+           <string>STEP export mode</string>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>step_exp_mode</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+          <item>
            <property name="text">
-            <string>main 3D folder location 'KISYS3DMOD'
-or 'KICAD6_3DMODEL_DIR'</string>
+            <string>Hierarchy</string>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::PrefFileChooser" name="main_prefix" native="true">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="baseSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;main 3D folder location&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;'KISYS3DMOD'&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="prefEntry" stdset="0">
-            <cstring>prefix3d_1</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-            <cstring>Mod/kicadStepUpGui</cstring>
-           </property>
-              <property name="mode">
-              <enum>Gui::FileChooser::Directory</enum>
-              </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="horizontalLayoutWidget_3">
-        <property name="geometry">
-         <rect>
-          <x>10</x>
-          <y>65</y>
-          <width>501</width>
-          <height>39</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_3">
-         <item>
-          <widget class="QLabel" name="label_prefix3d_2">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;ALIAS&lt;/span&gt; 3D&lt;/p&gt;&lt;p&gt;model prefix path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
+          </item>
+          <item>
            <property name="text">
-            <string>secondary 3D folder loc
-'ALT2 3DMOD'</string>
+            <string>Flat</string>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::PrefFileChooser" name="alias_prefix" native="true">
-           <property name="enabled">
-            <bool>true</bool>
+          </item>
+          <item>
+           <property name="text">
+            <string>One Container</string>
            </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="baseSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;secondary 3D folder location&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;'ALT3DMOD'&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="prefEntry" stdset="0">
-            <cstring>prefix3d_2</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-            <cstring>Mod/kicadStepUpGui</cstring>
-           </property>
-              <property name="mode">
-              <enum>Gui::FileChooser::Directory</enum>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QGroupBox" name="pcb_settings">
-        <property name="geometry">
-         <rect>
-          <x>-1</x>
-          <y>205</y>
-          <width>524</width>
-          <height>296</height>
-         </rect>
-        </property>
-        <property name="title">
-         <string>PCB settings</string>
-        </property>
-        <widget class="QWidget" name="layoutWidget_2">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>20</y>
-           <width>491</width>
-           <height>29</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_12">
-          <item>
-           <widget class="QLabel" name="label_20">
-            <property name="toolTip">
-             <string>PCBs color.</string>
-            </property>
-            <property name="text">
-             <string>PCB color</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
           </item>
-          <item>
-           <spacer name="horizontalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefComboBox" name="gui::prefcombobox_1">
-            <property name="toolTip">
-             <string>PCB color</string>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>pcb_color</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-            <item>
-             <property name="text">
-              <string>LightGreen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Green</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Blue</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Red</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Purple</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>DarkGreen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>DarkBlue</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>LightBlue</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Yellow</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Black</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>White</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="layoutWidget_3">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>50</y>
-           <width>491</width>
-           <height>29</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_13">
-          <item>
-           <widget class="QLabel" name="label_21">
-            <property name="toolTip">
-             <string>PCB Reference Placement in mechanical environment</string>
-            </property>
-            <property name="text">
-             <string>PCB Placement</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_6">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefComboBox" name="gui::prefcombobox_2">
-            <property name="toolTip">
-             <string>PCB Reference Placement in mechanical environment</string>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>pcb_placement</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-            <item>
-             <property name="text">
-              <string>Grid Origin</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Aux Origin</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Pcb Center (approx)</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="layoutWidget_4">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>80</y>
-           <width>491</width>
-           <height>29</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_14">
-          <item>
-           <widget class="QLabel" name="label_22">
-            <property name="toolTip">
-             <string>Constraints to be added to PCB Sketch</string>
-            </property>
-            <property name="text">
-             <string>PCB Sketch mode (constraints)</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_7">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefComboBox" name="gui::prefcombobox_3">
-            <property name="toolTip">
-             <string>Constraints to be added to PCB Sketch</string>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>sketch_constraints</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-            <item>
-             <property name="text">
-              <string>Coincident</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>V&amp;H, Coincident</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Full</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>None</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_virtual">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>140</y>
-           <width>463</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>Enable/Disable Virtual 3D
-(mechanical) models</string>
-         </property>
-         <property name="text">
-          <string>Virtual 3D Models loading</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>mode_virtual</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="QWidget" name="layoutWidget_5">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>165</y>
-           <width>491</width>
-           <height>30</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="toolTip">
-             <string>minimum Drill size applied to PCB
-'0.0' -&gt; all drills are loaded
-'-1' -&gt; all drills and vias are loaded</string>
-            </property>
-            <property name="text">
-             <string>minimum Drill size applied to PCB</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_8">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefLineEdit" name="lineEdit_drills">
-            <property name="toolTip">
-             <string>minimum Drill size applied to PCB
-'0.0' -&gt; all drills are loaded
-'-1' -&gt; all drills and vias are loaded</string>
-            </property>
-            <property name="text">
-             <string>0.0</string>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>drill_size</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="layoutWidget_7">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>195</y>
-           <width>491</width>
-           <height>30</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_6">
-          <item>
-           <widget class="QLabel" name="label_3">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bounding Box LIST:&lt;/span&gt;&lt;br/&gt;configure which 3D models will be converted to Bounding Box&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ALL&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;-&amp;gt; all models will be converted to bounding boxes&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;LIST&lt;/span&gt; DSUB-15-HD_FH, DSUB-9_FH &lt;span style=&quot; font-style:italic;&quot;&gt;-&amp;gt; these two models will NOT be converted to BBox&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;(list of 3D model's names separated by a semicolon)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Bounding Boxes</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_10">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefLineEdit" name="lineEdit_bbox">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bounding Box LIST:&lt;/span&gt;&lt;br/&gt;configure which 3D models will be converted to Bounding Box&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ALL&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;-&amp;gt; all models will be converted to bounding boxes&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;LIST&lt;/span&gt; DSUB-15-HD_FH, DSUB-9_FH &lt;span style=&quot; font-style:italic;&quot;&gt;-&amp;gt; these two models will NOT be converted to BBox&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;(list of 3D model's names separated by a semicolon)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>bbox_list</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="layoutWidget_8">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>225</y>
-           <width>491</width>
-           <height>30</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
-          <item>
-           <widget class="QLabel" name="label_4">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Black List:&lt;/span&gt;&lt;br/&gt;put here your model names that you don't want to load (e.g. smallest ones)&lt;br/&gt;separated by a semicolon.&lt;br/&gt;DNP or DNF attribute.&lt;br/&gt;volume and height are also configurable.&lt;br/&gt;(volume=1 means all models with a volume &amp;lt; 1mm3 will not be included)&lt;br/&gt;(height=1 means all models with a height &amp;lt; 1mm will not be included)&lt;br/&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;DNP;R_0402_1005Metric;C_0402_1005Metric;&lt;br/&gt;height=1.0&lt;br/&gt;volume=1.0&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;An empty list means all the models will be parsed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Black List</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_11">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefLineEdit" name="lineEdit_blackList">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Black List:&lt;/span&gt;&lt;br/&gt;put here your model names that you don't want to load (e.g. smallest ones)&lt;br/&gt;separated by a semicolon.&lt;br/&gt;DNP or DNF attribute.&lt;br/&gt;volume and height are also configurable.&lt;br/&gt;(volume=1 means all models with a volume &amp;lt; 1mm3 will not be included)&lt;br/&gt;(height=1 means all models with a height &amp;lt; 1mm will not be included)&lt;br/&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;DNP;R_0402_1005Metric;C_0402_1005Metric;&lt;br/&gt;height=1.0&lt;br/&gt;volume=1.0&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;An empty list means all the models will be parsed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>blacklist</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="layoutWidget_9">
-         <property name="geometry">
-          <rect>
-           <x>9</x>
-           <y>110</y>
-           <width>491</width>
-           <height>30</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <widget class="QLabel" name="label_2">
-            <property name="toolTip">
-             <string>minimum Edge Tolerance applied to PCB
-default '0.01mm'</string>
-            </property>
-            <property name="text">
-             <string>minimum edge tolerance</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_12">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefLineEdit" name="lineEdit_edgeTolerance">
-            <property name="toolTip">
-             <string>minimum Edge Tolerance applied to PCB
-default '0.01mm'</string>
-            </property>
-            <property name="text">
-             <string>0.01</string>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>edge_tolerance</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="layoutWidget_10">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>255</y>
-           <width>491</width>
-           <height>30</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_10">
-          <item>
-           <widget class="QLabel" name="label_5">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;White List:&lt;/span&gt;&lt;br/&gt;put here your model names that you must load (e.g. smallest ones)&lt;br/&gt;separated by a semicolon.&lt;br/&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;
-LED_D5.0mm_IRBlack;USB_Mini-B_Lumberg_2486_01_Horizontal;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;An empty list means all the models will behave as usual.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>White List</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_13">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefLineEdit" name="lineEdit_whiteList">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;White List:&lt;/span&gt;&lt;br/&gt;put here your model names that you must load (e.g. smallest ones)&lt;br/&gt;separated by a semicolon.&lt;br/&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;
-LED_D5.0mm_IRBlack;USB_Mini-B_Lumberg_2486_01_Horizontal;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;An empty list means all the models will behave as usual.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>whitelist</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-       <widget class="QGroupBox" name="imp_exp_setting">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>500</y>
-          <width>525</width>
-          <height>331</height>
-         </rect>
-        </property>
-        <property name="title">
-         <string>Import/Export settings</string>
-        </property>
-        <widget class="Gui::PrefCheckBox" name="cb_make_union">
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>25</y>
-           <width>463</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable/Disable &lt;span style=&quot; font-weight:600;&quot;&gt;fusion (union)&lt;/span&gt; of all 3D models.&lt;/p&gt;&lt;p&gt;Be careful ... fusion can be heavy or generate FC crash with a lot of objects.&lt;/p&gt;&lt;p&gt;Please consider to use bbox or blacklist small objects&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Make a Union of 3D models</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>make_union</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_exp_step">
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>50</y>
-           <width>463</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Directly &lt;span style=&quot; font-weight:600;&quot;&gt;Export STEP&lt;/span&gt; after Loading&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Directly Export STEP after Loading</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>exp_step</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="QWidget" name="layoutWidget">
-         <property name="geometry">
-          <rect>
-           <x>9</x>
-           <y>80</y>
-           <width>491</width>
-           <height>29</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_11">
-          <item>
-           <widget class="QLabel" name="label_19">
-            <property name="toolTip">
-             <string>STEP export mode.</string>
-            </property>
-            <property name="text">
-             <string>STEP export mode</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefComboBox" name="gui::prefcombobox_4">
-            <property name="toolTip">
-             <string>STEP export mode</string>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>step_exp_mode</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-            <item>
-             <property name="text">
-              <string>Hierarchy</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Flat</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>One Container</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="layoutWidget_6">
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>110</y>
-           <width>491</width>
-           <height>29</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_15">
-          <item>
-           <widget class="QLabel" name="label_23">
-            <property name="toolTip">
-             <string>3D Loading mode.</string>
-            </property>
-            <property name="text">
-             <string>3D Loading mode</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_9">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="Gui::PrefComboBox" name="gui::prefcombobox_5">
-            <property name="toolTip">
-             <string>3D_loading_mode
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_15">
+        <item>
+         <widget class="QLabel" name="label_23">
+          <property name="toolTip">
+           <string>3D Loading mode.</string>
+          </property>
+          <property name="text">
+           <string>3D Loading mode</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_9">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_5">
+          <property name="toolTip">
+           <string>3D_loading_mode
 Allowing or not Loading Multi Parts objects</string>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <property name="prefEntry" stdset="0">
-             <cstring>3D_loading_mode</cstring>
-            </property>
-            <property name="prefPath" stdset="0">
-             <cstring>Mod/kicadStepUpGui</cstring>
-            </property>
-            <item>
-             <property name="text">
-              <string>Hierarchy</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Simplified</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>NotMultiParts</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Standard</string>
-             </property>
-            </item>
-           </widget>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>3D_loading_mode</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Hierarchy</string>
+           </property>
           </item>
-         </layout>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_asm3_links">
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>145</y>
-           <width>246</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>Assembly3 Links allowed.</string>
-         </property>
-         <property name="text">
-          <string>Assembly3 Links allowed</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>asm3_links</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_vrml_materials">
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>170</y>
-           <width>463</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>Enables Materials for VRML exporting.</string>
-         </property>
-         <property name="statusTip">
-          <string notr="true"/>
-         </property>
-         <property name="text">
-          <string>Enable Materials for VRML exporting</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>vrml_materials</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_turntable">
-         <property name="geometry">
-          <rect>
-           <x>9</x>
-           <y>295</y>
-           <width>225</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>Start Turntable after loading.</string>
-         </property>
-         <property name="text">
-          <string>Start Turntable after loading</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>turntable</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_asm3_links_2">
-         <property name="geometry">
-          <rect>
-           <x>267</x>
-           <y>145</y>
-           <width>246</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>Assembly3 LinkGroups allowed.</string>
-         </property>
-         <property name="text">
-          <string>Assembly3 LinkGroups allowed</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>asm3_linkGroups</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_stpz_export">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>220</y>
-           <width>463</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>Enables compressed STEP file ('.stpZ') generation exporting.</string>
-         </property>
-         <property name="text">
-          <string>Enable compressed STEP file ('.stpZ') generation exporting</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>stpz_export_enabled</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_wrz_export">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>195</y>
-           <width>463</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>Enables compressed VRML file ('.wrz') generation exporting.</string>
-         </property>
-         <property name="text">
-          <string>Enable compressed VRML file ('.wrz') generation exporting</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>wrz_export_enabled</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_help_warn">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>270</y>
-           <width>463</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>Displays STEP import settings warning.</string>
-         </property>
-         <property name="text">
-          <string>Display STEP import settings warning</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>help_warning_enabled</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_transparency_export_glass">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>8</x>
-           <y>245</y>
-           <width>264</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply Transparency for 'Glass' Materials:&lt;/p&gt;&lt;p&gt;Force Transparency to STEP model if 'Glass' is found in '.wrl' model&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Apply Transparency for 'Glass' Materials</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>transparency_material_glass_enabled</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_transparency_export_led">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>270</x>
-           <y>245</y>
-           <width>264</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply Transparency for 'Led' Materials:&lt;/p&gt;&lt;p&gt;Force Transparency to STEP model if 'Led' is found in '.wrl' model&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Apply Transparency for 'Led' Materials</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>transparency_material_led_enabled</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_skip_zones">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>270</x>
-           <y>295</y>
-           <width>71</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Skip importing pcb zone(s)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>skpZone</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>skip_import_zones</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_skip_tracks">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>345</x>
-           <y>295</y>
-           <width>86</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Skip importing pcb tracks and vias&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>skpTracks</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>skip_import_tracks</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-        <widget class="Gui::PrefCheckBox" name="cb_skip_pads">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="geometry">
-          <rect>
-           <x>435</x>
-           <y>295</y>
-           <width>79</width>
-           <height>20</height>
-          </rect>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Skip importing pcb pads&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>skpPads</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="tristate">
-          <bool>false</bool>
-         </property>
-         <property name="prefEntry" stdset="0">
-          <cstring>skip_import_pads</cstring>
-         </property>
-         <property name="prefPath" stdset="0">
-          <cstring>Mod/kicadStepUpGui</cstring>
-         </property>
-        </widget>
-       </widget>
-       <widget class="QWidget" name="horizontalLayoutWidget_4">
-        <property name="geometry">
-         <rect>
-          <x>10</x>
-          <y>105</y>
-          <width>501</width>
-          <height>39</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
-         <item>
-          <widget class="QLabel" name="label_prefix3d_3">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;ALIAS&lt;/span&gt; 3D&lt;/p&gt;&lt;p&gt;model prefix path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
+          <item>
            <property name="text">
-            <string>third 3D folder loc
+            <string>Simplified</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>NotMultiParts</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Standard</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_asm3_links">
+          <property name="toolTip">
+           <string>Assembly3 Links allowed.</string>
+          </property>
+          <property name="text">
+           <string>Assembly3 Links allowed</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>asm3_links</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_15">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_asm3_links_2">
+          <property name="toolTip">
+           <string>Assembly3 LinkGroups allowed.</string>
+          </property>
+          <property name="text">
+           <string>Assembly3 LinkGroups allowed</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>asm3_linkGroups</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_vrml_materials">
+        <property name="toolTip">
+         <string>Enables Materials for VRML exporting.</string>
+        </property>
+        <property name="statusTip">
+         <string notr="true"/>
+        </property>
+        <property name="text">
+         <string>Enable Materials for VRML exporting</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="tristate">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>vrml_materials</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/kicadStepUpGui</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_wrz_export">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Enables compressed VRML file ('.wrz') generation exporting.</string>
+        </property>
+        <property name="text">
+         <string>Enable compressed VRML file ('.wrz') generation exporting</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="tristate">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>wrz_export_enabled</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/kicadStepUpGui</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_stpz_export">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Enables compressed STEP file ('.stpZ') generation exporting.</string>
+        </property>
+        <property name="text">
+         <string>Enable compressed STEP file ('.stpZ') generation exporting</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="tristate">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>stpz_export_enabled</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/kicadStepUpGui</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_16">
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_transparency_export_glass">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply Transparency for 'Glass' Materials:&lt;/p&gt;&lt;p&gt;Force Transparency to STEP model if 'Glass' is found in '.wrl' model&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Apply Transparency for 'Glass' Materials</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="tristate">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>transparency_material_glass_enabled</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_16">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_transparency_export_led">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply Transparency for 'Led' Materials:&lt;/p&gt;&lt;p&gt;Force Transparency to STEP model if 'Led' is found in '.wrl' model&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Apply Transparency for 'Led' Materials</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="tristate">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>transparency_material_led_enabled</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_help_warn">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Displays STEP import settings warning.</string>
+        </property>
+        <property name="text">
+         <string>Display STEP import settings warning</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="tristate">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>help_warning_enabled</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/kicadStepUpGui</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_17">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_turntable">
+          <property name="toolTip">
+           <string>Start Turntable after loading.</string>
+          </property>
+          <property name="text">
+           <string>Start Turntable after loading</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>turntable</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_17">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_skip_zones">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Skip importing pcb zone(s)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>skpZone</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="tristate">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>skip_import_zones</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_skip_tracks">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Skip importing pcb tracks and vias&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>skpTracks</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="tristate">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>skip_import_tracks</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefCheckBox" name="cb_skip_pads">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Skip importing pcb pads&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>skpPads</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="tristate">
+           <bool>false</bool>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>skip_import_pads</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="pcb_settings">
+     <property name="title">
+      <string>PCB settings</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_12">
+        <item>
+         <widget class="QLabel" name="label_20">
+          <property name="toolTip">
+           <string>PCBs color.</string>
+          </property>
+          <property name="text">
+           <string>PCB color</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_1">
+          <property name="toolTip">
+           <string>PCB color</string>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>pcb_color</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>LightGreen</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Green</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Blue</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Red</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Purple</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>DarkGreen</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>DarkBlue</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>LightBlue</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Yellow</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Black</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>White</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_13">
+        <item>
+         <widget class="QLabel" name="label_21">
+          <property name="toolTip">
+           <string>PCB Reference Placement in mechanical environment</string>
+          </property>
+          <property name="text">
+           <string>PCB Placement</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_2">
+          <property name="toolTip">
+           <string>PCB Reference Placement in mechanical environment</string>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>pcb_placement</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Grid Origin</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Aux Origin</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Pcb Center (approx)</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_14">
+        <item>
+         <widget class="QLabel" name="label_22">
+          <property name="toolTip">
+           <string>Constraints to be added to PCB Sketch</string>
+          </property>
+          <property name="text">
+           <string>PCB Sketch mode (constraints)</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="gui::prefcombobox_3">
+          <property name="toolTip">
+           <string>Constraints to be added to PCB Sketch</string>
+          </property>
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>sketch_constraints</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+          <item>
+           <property name="text">
+            <string>Coincident</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>V&amp;H, Coincident</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Full</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>None</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="toolTip">
+           <string>minimum Edge Tolerance applied to PCB
+default '0.01mm'</string>
+          </property>
+          <property name="text">
+           <string>minimum edge tolerance</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_12">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefLineEdit" name="lineEdit_edgeTolerance">
+          <property name="toolTip">
+           <string>minimum Edge Tolerance applied to PCB
+default '0.01mm'</string>
+          </property>
+          <property name="text">
+           <string>0.01</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>edge_tolerance</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="cb_virtual">
+        <property name="toolTip">
+         <string>Enable/Disable Virtual 3D
+(mechanical) models</string>
+        </property>
+        <property name="text">
+         <string>Virtual 3D Models loading</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>mode_virtual</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/kicadStepUpGui</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="toolTip">
+           <string>minimum Drill size applied to PCB
+'0.0' -&gt; all drills are loaded
+'-1' -&gt; all drills and vias are loaded</string>
+          </property>
+          <property name="text">
+           <string>minimum Drill size applied to PCB</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefLineEdit" name="lineEdit_drills">
+          <property name="toolTip">
+           <string>minimum Drill size applied to PCB
+'0.0' -&gt; all drills are loaded
+'-1' -&gt; all drills and vias are loaded</string>
+          </property>
+          <property name="text">
+           <string>0.0</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>drill_size</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bounding Box LIST:&lt;/span&gt;&lt;br/&gt;configure which 3D models will be converted to Bounding Box&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ALL&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;-&amp;gt; all models will be converted to bounding boxes&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;LIST&lt;/span&gt; DSUB-15-HD_FH, DSUB-9_FH &lt;span style=&quot; font-style:italic;&quot;&gt;-&amp;gt; these two models will NOT be converted to BBox&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;(list of 3D model's names separated by a semicolon)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Bounding Boxes</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_10">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefLineEdit" name="lineEdit_bbox">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Bounding Box LIST:&lt;/span&gt;&lt;br/&gt;configure which 3D models will be converted to Bounding Box&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;ALL&lt;/span&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;-&amp;gt; all models will be converted to bounding boxes&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;LIST&lt;/span&gt; DSUB-15-HD_FH, DSUB-9_FH &lt;span style=&quot; font-style:italic;&quot;&gt;-&amp;gt; these two models will NOT be converted to BBox&lt;/span&gt;&lt;br/&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;(list of 3D model's names separated by a semicolon)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>bbox_list</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_7">
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Black List:&lt;/span&gt;&lt;br/&gt;put here your model names that you don't want to load (e.g. smallest ones)&lt;br/&gt;separated by a semicolon.&lt;br/&gt;DNP or DNF attribute.&lt;br/&gt;volume and height are also configurable.&lt;br/&gt;(volume=1 means all models with a volume &amp;lt; 1mm3 will not be included)&lt;br/&gt;(height=1 means all models with a height &amp;lt; 1mm will not be included)&lt;br/&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;DNP;R_0402_1005Metric;C_0402_1005Metric;&lt;br/&gt;height=1.0&lt;br/&gt;volume=1.0&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;An empty list means all the models will be parsed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Black List</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_11">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefLineEdit" name="lineEdit_blackList">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Black List:&lt;/span&gt;&lt;br/&gt;put here your model names that you don't want to load (e.g. smallest ones)&lt;br/&gt;separated by a semicolon.&lt;br/&gt;DNP or DNF attribute.&lt;br/&gt;volume and height are also configurable.&lt;br/&gt;(volume=1 means all models with a volume &amp;lt; 1mm3 will not be included)&lt;br/&gt;(height=1 means all models with a height &amp;lt; 1mm will not be included)&lt;br/&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;DNP;R_0402_1005Metric;C_0402_1005Metric;&lt;br/&gt;height=1.0&lt;br/&gt;volume=1.0&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;An empty list means all the models will be parsed.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>blacklist</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_10">
+        <item>
+         <widget class="QLabel" name="label_5">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;White List:&lt;/span&gt;&lt;br/&gt;put here your model names that you must load (e.g. smallest ones)&lt;br/&gt;separated by a semicolon.&lt;br/&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;
+LED_D5.0mm_IRBlack;USB_Mini-B_Lumberg_2486_01_Horizontal;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;An empty list means all the models will behave as usual.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>White List</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_13">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefLineEdit" name="lineEdit_whiteList">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;White List:&lt;/span&gt;&lt;br/&gt;put here your model names that you must load (e.g. smallest ones)&lt;br/&gt;separated by a semicolon.&lt;br/&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Examples:&lt;/span&gt;&lt;br/&gt;
+LED_D5.0mm_IRBlack;USB_Mini-B_Lumberg_2486_01_Horizontal;&lt;br/&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;An empty list means all the models will behave as usual.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>whitelist</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="prefix_3d_group">
+     <property name="title">
+      <string>3D Prefix working folder</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_prefix3d_1">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;KISYS3DMOD&lt;/span&gt; path&lt;/p&gt;&lt;p&gt;or 3D model &lt;span style=&quot; font-weight:600;&quot;&gt;main prefix path&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>main 3D folder location 'KISYS3DMOD'
+or 'KICAD6_3DMODEL_DIR'</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefFileChooser" name="main_prefix">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;main 3D folder location&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;'KISYS3DMOD'&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="mode">
+           <enum>Gui::FileChooser::Directory</enum>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>prefix3d_1</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QLabel" name="label_prefix3d_2">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;ALIAS&lt;/span&gt; 3D&lt;/p&gt;&lt;p&gt;model prefix path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>secondary 3D folder loc
+'ALT2 3DMOD'</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefFileChooser" name="alias_prefix">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;secondary 3D folder location&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;'ALT3DMOD'&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="mode">
+           <enum>Gui::FileChooser::Directory</enum>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>prefix3d_2</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <item>
+         <widget class="QLabel" name="label_prefix3d_3">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;ALIAS&lt;/span&gt; 3D&lt;/p&gt;&lt;p&gt;model prefix path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>third 3D folder loc
 'ALT3 3DMOD'</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::PrefFileChooser" name="alias_prefix_2" native="true">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="baseSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;secondary 3D folder location&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;'ALT3DMOD'&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="prefEntry" stdset="0">
-            <cstring>prefix3d_3</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-            <cstring>Mod/kicadStepUpGui</cstring>
-           </property>
-              <property name="mode">
-              <enum>Gui::FileChooser::Directory</enum>
-           </property>
-           </widget>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="horizontalLayoutWidget_5">
-        <property name="geometry">
-         <rect>
-          <x>10</x>
-          <y>145</y>
-          <width>501</width>
-          <height>39</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_9">
-         <item>
-          <widget class="QLabel" name="label_prefix3d_4">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;ALIAS&lt;/span&gt; 3D&lt;/p&gt;&lt;p&gt;model prefix path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>fourth 3D folder loc
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefFileChooser" name="alias_prefix_2">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;secondary 3D folder location&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;'ALT3DMOD'&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="mode">
+           <enum>Gui::FileChooser::Directory</enum>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>prefix3d_3</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_9">
+        <item>
+         <widget class="QLabel" name="label_prefix3d_4">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;your &lt;span style=&quot; font-weight:600;&quot;&gt;ALIAS&lt;/span&gt; 3D&lt;/p&gt;&lt;p&gt;model prefix path&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>fourth 3D folder loc
 'ALT4 3DMOD'</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="Gui::PrefFileChooser" name="alias_prefix_3" native="true">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="baseSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;secondary 3D folder location&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;'ALT3DMOD'&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="prefEntry" stdset="0">
-            <cstring>prefix3d_4</cstring>
-           </property>
-           <property name="prefPath" stdset="0">
-            <cstring>Mod/kicadStepUpGui</cstring>
-           </property>
-              <property name="mode">
-              <enum>Gui::FileChooser::Directory</enum>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_14">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="Gui::PrefFileChooser" name="alias_prefix_3">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="baseSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;secondary 3D folder location&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;'ALT3DMOD'&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="mode">
+           <enum>Gui::FileChooser::Directory</enum>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>prefix3d_4</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/kicadStepUpGui</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <widget class="Gui::PrefCheckBox" name="cb_dontuseNativeDlg">
-        <property name="geometry">
-         <rect>
-          <x>8</x>
-          <y>180</y>
-          <width>463</width>
-          <height>20</height>
-         </rect>
-        </property>
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select to NOT use the native dialog box in Open/Save files&lt;br/&gt;(suggested for Snap or FlatPack)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
@@ -1438,28 +1286,18 @@ Allowing or not Loading Multi Parts objects</string>
          <cstring>Mod/kicadStepUpGui</cstring>
         </property>
        </widget>
-      </widget>
-      <widget class="QGroupBox" name="mcad_compare">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>835</y>
-         <width>525</width>
-         <height>51</height>
-        </rect>
-       </property>
-       <property name="title">
-        <string>Mechanical Check</string>
-       </property>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QGroupBox" name="mcad_compare">
+     <property name="title">
+      <string>Mechanical Check</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
        <widget class="Gui::PrefCheckBox" name="cb_gen_sketch">
-        <property name="geometry">
-         <rect>
-          <x>11</x>
-          <y>25</y>
-          <width>463</width>
-          <height>21</height>
-         </rect>
-        </property>
         <property name="toolTip">
          <string>Generates Sketches for differences on PCB Edge.</string>
         </property>
@@ -1476,8 +1314,8 @@ Allowing or not Loading Multi Parts objects</string>
          <cstring>Mod/kicadStepUpGui</cstring>
         </property>
        </widget>
-      </widget>
-     </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/demo/kicad-StepUp-tools.FCMacro
+++ b/demo/kicad-StepUp-tools.FCMacro
@@ -14972,7 +14972,7 @@ class Ui_DockWidget(object):
             #if "ksuWB" not in FreeCADGui.activeWorkbench().name():
             if 'pref_page' not in globals():
                 FreeCADGui.activateWorkbench("KiCadStepUpWB")
-            FreeCADGui.runCommand("Std_DlgPreferences")
+            FreeCADGui.showPreferences("kicadStepUpGui")
         elif expanded_view!=1:
             temporary_undock() #to do ....
             #undock()

--- a/hlp.py
+++ b/hlp.py
@@ -7,30 +7,25 @@ import ksu_locator, os
 
 ksuWBpath = os.path.dirname(ksu_locator.__file__)
 
-font_color = "<font color=black>"
+# font_color = "<font color=black>"
 
 import FreeCAD, FreeCADGui
 
 # paramGet = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/MainWindow")
 # if 'dark' in paramGet.GetString("StyleSheet").lower(): #we are using a StyleSheet
-font_color = "<font color=ghostwhite>"
+# font_color = "<font color=ghostwhite>"
 from PySide2 import QtGui
 from TranslateUtils import translate
 
-font_color = (
-    "<font color=" + FreeCADGui.getMainWindow().palette().text().color().name() + ">"
-)
-# FreeCADGui.getMainWindow().palette().background().color()
+font_color = "<font color=" + FreeCADGui.getMainWindow().palette().text().color().name() + ">"
 
+# FreeCADGui.getMainWindow().palette().background().color()
 # help_txt="""<font color=GoldenRod><b>kicad StepUp version """+verKSU+"""</font></b><br>"""
-help_txt = "<font color=black>"
-help_txt += font_color
-help_txt += translate(
+
+help_txt = translate(
     "Help",
-    "<b>Kicad StepUp</b> is a tool set to easily <b>collaborate between kicad pcb EDA</b> (board and 3D parts) as STEP models <b>and FreeCAD MCAD</b> modeler.<br>\n"
-    "</font>",
+    "<b>Kicad StepUp</b> is a tool set to easily <b>collaborate between kicad pcb EDA</b> (board and 3D parts) as STEP models <b>and FreeCAD MCAD</b> modeler.<br>\n",
 )
-help_txt += font_color
 help_txt += translate(
     "Help",
     "<b>StepUp</b> can also be used <b>to align 3D model to kicad footprint</b>.<br>\n"
@@ -77,6 +72,5 @@ help_txt += translate(
     "<br><b>NB<br>STEP model has to be fused in single object</b><br>(Part Boolean Union of objects)\n"
     "<br><b>or a Compoud</b> (Part Makecompound of objects)</b>\n"
     "<hr><b>enable 'Report view' Panel to see helping messages</b>\n"
-    "</font>\n"
     "<br>",
 )

--- a/kicadStepUpCMD.py
+++ b/kicadStepUpCMD.py
@@ -3881,7 +3881,7 @@ class ksuToolsEditPrefs:
         #import kicadStepUptools
         # import hlp
         # reload_lib(hlp)
-        FreeCADGui.runCommand("Std_DlgPreferences")
+        FreeCADGui.showPreferences("kicadStepUpGui")
         
 FreeCADGui.addCommand('ksuToolsEditPrefs',ksuToolsEditPrefs())
 
@@ -3909,7 +3909,7 @@ class ksuOpDXF:
         #import kicadStepUptools
         # import hlp
         # reload_lib(hlp)
-        #FreeCADGui.runCommand("Std_DlgPreferences") 
+        #FreeCADGui.showPreferences("kicadStepUpGui") 
         
         import _DXF_Import
         import os
@@ -3955,7 +3955,7 @@ class ksuOpEzDXF:
         #import kicadStepUptools
         # import hlp
         # reload_lib(hlp)
-        #FreeCADGui.runCommand("Std_DlgPreferences") 
+        #FreeCADGui.showPreferences("kicadStepUpGui") 
         from ezDXF_import import open_ezdxf
         try:
             import ezdxf
@@ -4003,7 +4003,7 @@ class ksuImpDXF:
         #import kicadStepUptools
         # import hlp
         # reload_lib(hlp)
-        #FreeCADGui.runCommand("Std_DlgPreferences") 
+        #FreeCADGui.showPreferences("kicadStepUpGui") 
         
         import _DXF_Import
         from dxf_parser import _importDXF
@@ -4052,7 +4052,7 @@ if 0:
             #import kicadStepUptools
             # import hlp
             # reload_lib(hlp)
-            FreeCADGui.runCommand("Std_DlgPreferences")
+            FreeCADGui.showPreferences("kicadStepUpGui")
             
     FreeCADGui.addCommand('ksuExpDXF',ksuExpDXF())
 #####

--- a/kicadStepUptools.py
+++ b/kicadStepUptools.py
@@ -14853,7 +14853,7 @@ class Ui_DockWidget(object):
             #if "ksuWB" not in FreeCADGui.activeWorkbench().name():
             if 'pref_page' not in globals():
                 FreeCADGui.activateWorkbench("KiCadStepUpWB")
-            FreeCADGui.runCommand("Std_DlgPreferences")
+            FreeCADGui.showPreferences("kicadStepUpGui")
         elif expanded_view!=1:
             temporary_undock() #to do ....
             #undock()


### PR DESCRIPTION
Is possible to open the KiCadStepUp preference page that was added using `addPreferencePage()` command.

**All testing was made on dev branch.**

Removing color from help tips is's better because it works on both light and dark themes. (Tested default and OpenDark)
```shell
freecad --user-cfg /dev/null --system-cfg /dev/null
```

![image](https://github.com/easyw/kicadStepUpMod/assets/53124818/46085a54-f814-4a11-996f-508077a5853a)

Responsive preference page, no variables or text were modifed only layout:
![image](https://github.com/easyw/kicadStepUpMod/assets/53124818/70752e1c-27a0-40e5-b74c-9198ce645715)

To select adequate layout:
![image](https://github.com/easyw/kicadStepUpMod/assets/53124818/105e50c5-fd74-4fb0-8305-2565c7cd23b2)
