### PR TITLE
Search for Combo View in a loop

### DIFF
--- a/kicadStepUptools.py
+++ b/kicadStepUptools.py
@@ -21732,6 +21732,12 @@ if singleInstance():
         cv = t.findChild(QtGui.QDockWidget, "Model")
         if cv is None:
             cv = t.findChild(QtGui.QDockWidget, "Tree view")
+            if cv is None:
+                cv = [o for o in t.children () if o.objectName () == "Combo View"]
+                if cv:
+                    cv = cv[0]
+                else:
+                    cv = None
     #say( "Combo View" + str(cv))
     ## print( "KSUWidget" + str(wf))        
     cv.setFeatures( QtGui.QDockWidget.DockWidgetMovable | QtGui.QDockWidget.DockWidgetFloatable|QtGui.QDockWidget.DockWidgetClosable )


### PR DESCRIPTION
On my end, when I try use some of the KSU action button, such as `Export 3D Model`, the window fails to open:

<pre>
11:47:29  PoM not present
11:47:29  using 'Part' container and 'Links'
11:47:29  FC Version 021-2
11:47:29  kicad StepUp version 12.0.3
11:47:29  tolerance on vertex applied
11:47:29  applying Materials to Shapes
11:47:29  your home path is /home/mmp
11:47:29  export to STEP False
11:47:29  Running the Python command 'ksuToolsExportModel' failed:
Traceback (most recent call last):
  File "/home/mmp/.local/share/FreeCAD/Mod/kicadStepUpMod/./kicadStepUpCMD.py", line 1289, in Activated
    from kicadStepUptools import routineScaleVRML
  File "/home/mmp/.local/share/FreeCAD/Mod/kicadStepUpMod/./kicadStepUptools.py", line 21737, in 
    cv.setFeatures( QtGui.QDockWidget.DockWidgetMovable | QtGui.QDockWidget.DockWidgetFloatable|QtGui.QDockWidget.DockWidgetClosable )
    ^^^^^^^^^^^^^^

'NoneType' object has no attribute 'setFeatures'
</pre>

So I added a loop to iteratively search for `Combo View` and this fixes this issue on my end. There's a similar code it the `tabify()` function, but fixing that the same way causes bigger problems on the lines after it, so that's why this fix is only for the `singleInstance()` function. I make an issue about this too: https://github.com/easyw/kicadStepUpMod/issues/220