### PR TITLE
Compatibility fix: Adjust module importing to support FreeCAD variants

### DIFF
--- a/kicad_parser.py
+++ b/kicad_parser.py
@@ -21,11 +21,11 @@ import Part
 from FreeCAD import Console,Vector,Placement,Rotation
 import DraftGeomUtils,DraftVecUtils
 
-if FreeCAD.Version()[0] < '1':
+try:
+    import CAM
+except:
     import Path
     CAM = Path
-else:
-    import CAM
 
 import sys, os
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
Changes the way modules are imported to prevent module errors when using other FreeCAD forks/variants such as RealThunder's Link branch