### PR TITLE
fix CAM import for stable FreeCAD release

### DIFF
--- a/kicad_parser.py
+++ b/kicad_parser.py
@@ -22,10 +22,10 @@ from FreeCAD import Console,Vector,Placement,Rotation
 import DraftGeomUtils,DraftVecUtils
 
 try:
-    import CAM
-except:
     import Path
     CAM = Path
+except:
+    import CAM
 
 import sys, os
 sys.path.append(os.path.dirname(os.path.realpath(__file__)))


### PR DESCRIPTION
**Issue:**
---
In stable FC 1.0.0, `Add Tracks` fails when creating some footprint geometries with the error:
> module 'CAM' has no attribute 'Area'

This appears to happen because the new stable version reverted the `Path` workbench name back to `CAM`; possibly for backward compatibility.

![FC-0 20](https://github.com/user-attachments/assets/210ef93c-713d-413e-9aca-a57a1b127b17) ![FC-1 0 0](https://github.com/user-attachments/assets/2c53b79c-155d-4915-af56-f2e7f7b34f52)
_Left:  v0.20 'Path' workbench. Right: v1.0.0 renamed back to 'CAM' workbench._


A previous try/except statement patch (996e60986e0e9c67691213045174669fb1926be9) tried to accommodate various builds using the older CAM module, however this now fails in the stable release.

**Resolution:**
---
Reverse the order of the import try statement. Ensure that the first attempt to load refers to the more up-to-date `Path` module, and falls back to the older `CAM` module only if the `Path` module is not found.

This has been tested on the current stable version FC-1.0.0 and and older version FC-0.20.