### PR TITLE
Minor fixes for commit_num.py

### DIFF
--- a/commits_num.py
+++ b/commits_num.py
@@ -1,3 +1,4 @@
+import FreeCAD
 import re
 
 # from https://gist.github.com/codsane/25f0fd100b565b3fce03d4bbd7e7bf33


### PR DESCRIPTION
Hi,

thanks for your Mod, made exporting my first 3D model to Kicad really easy.

I noticed these two minor issues when first starting the workbench.

Best,
Simon

PS: I noticed a lot more SyntaxWarning in commit_num.py but these were non obvious.
PPS: Having the version check default to off would be nicer behavior.