### PR TITLE
Fix UnicodeDecodeError when loading footprints on macOS/Python 3

### DIFF
--- a/fps.py
+++ b/fps.py
@@ -382,7 +382,7 @@ def addfootprint(fname = None):
         fn=os.path.splitext(os.path.basename(filename))[0]
     
         if filename.endswith('kicad_mod'):
-            with open(filename , 'r') as f:
+            with open(filename , 'r', encoding="utf-8", errors="ignore") as f:
                 lines = f.readlines() # readlines creates a list of the lines
             #lines = start_f+lines+end_f
             import tempfile


### PR DESCRIPTION
## Description
This PR fixes a `UnicodeDecodeError` encountered when trying to load a `.kicad_mod` footprint file containing non-ASCII characters (e.g., hidden NBSP bytes like `0xC2`) on macOS.

Without explicit encoding definitions, Python 3 defaults to `ascii` in some environments, causing the plugin to crash when reading these files.

## The Issue
When attempting to load a custom footprint in FreeCAD via ksu, the following traceback occurs:

```text
Traceback (most recent call last):
  File ".../kicadStepUpMod/./kicadStepUptools.py", line 14958, in onLoadFootprint_click
    fps.addfootprint()
  File ".../kicadStepUpMod/./fps.py", line 386, in addfootprint
    lines = f.readlines()
  File ".../encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 2099: ordinal not in range(128)
```

## The Fix
I updated the `open()` function in `fps.py` to explicitly use `encoding="utf-8"` and `errors="ignore"`. This ensures that footprint files are read correctly regardless of the system's default encoding settings.

## Verification
- Tested on macOS with FreeCAD and KiCad 9 generator files.
- The error is resolved, and the footprint loads successfully.