### PR TITLE
tracks: Fix traceback when canceling track import

### DIFF
--- a/tracks.py
+++ b/tracks.py
@@ -328,6 +328,11 @@ def addtracks(fname = None):
         path, name = os.path.split(fname)
     #filename=os.path.splitext(name)[0]
     filename = fname
+
+    # Return early if file dialog was cancelled
+    if not fname:
+        return []
+
     #importDXF.open(os.path.join(dirname,filename))
     if len(fname) > 0:
         start_time=current_milli_time()


### PR DESCRIPTION
When closing file dialog without selecting the file we got a harmless traceback in console.
Also, with this early return in place, we can also reduce nesting in the `addtracks` function.